### PR TITLE
Cut -std=c++11 reference out of alternative installation notes

### DIFF
--- a/INSTALL-DESKTOP.md
+++ b/INSTALL-DESKTOP.md
@@ -1,6 +1,6 @@
 # Notes for installing WGA_GPU locally on a desktop
 
-This worked on my Ubuntu 18.04 desktop with a 4G GeForce GTX 1050 Ti.  It may be useful for others wishing to try the software on their laptop or desktop (as opposed to an AWS G3 or P3 instance). 
+This is an alternative way to install CUDA that worked on my Ubuntu 18.04 desktop with a 4G GeForce GTX 1050 Ti.  It may be useful for others wishing to try the software on their laptop or desktop (as opposed to an AWS G3 or P3 instance) and for whom the CUDA installation in the `install.sh` script doesn't work. 
 
 ## Install CUDA-9 and Nvidia drivers
 
@@ -66,32 +66,6 @@ Using the `-c` option skips CUDA installation, as it was already done above.  No
 
 ```
 ./install.sh -c
-```
-
-Whe using CUDA 9 as installed manually above, I got the following error when building wga in the `install.sh` script:
-```
-/WGA_GPU/build$ make
-[ 11%] Building CXX object CMakeFiles/wga.dir/DRAM.cpp.o
-In file included from /home/hickey/dev/WGA_GPU/DRAM.cpp:5:0:
-/home/hickey/dev/WGA_GPU/tbb/include/tbb/tbb.h:21:154: note: #pragma message: TBB Warning: tbb.h contains deprecated functionality. For details, please see Deprecated Features appendix in the TBB reference manual.
- .h contains deprecated functionality. For details, please see Deprecated Features appendix in the TBB reference manual.")
-                                                                                                                         ^
-[ 22%] Building CUDA object CMakeFiles/wga.dir/GPU.cu.o
-nvcc fatal   : redefinition of argument 'std'
-CMakeFiles/wga.dir/build.make:86: recipe for target 'CMakeFiles/wga.dir/GPU.cu.o' failed
-make[2]: *** [CMakeFiles/wga.dir/GPU.cu.o] Error 1
-CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/wga.dir/all' failed
-make[1]: *** [CMakeFiles/wga.dir/all] Error 2
-Makefile:83: recipe for target 'all' failed
-make: *** [all] Error 2
-
-```
-Removing the occurrences of `-std=c++11` from CMakeLists.txt resolved it:
-```
-sed -i 's/-std=c++11//g' CMakeLists.txt
-cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DTBB_ROOT=${PWD}/../tbb ..
-make -j $(nproc)
 ```
 
 As a developer, I find it easier to work with the local `wga` binary and scripts:


### PR DESCRIPTION
Specifying in `CMAKE_CXX_FLAGS` but not `CMAKE_CUDA_FLAGS` as done in the current master fixes everything.  

This whole document is increasingly unncessary due to this and related patches in master.  I think the alternative CUDA installation steps may be worth keeping around though.  