### PR TITLE
Add back support for special chars in fasta sequence names

### DIFF
--- a/bin/run_wga_gpu
+++ b/bin/run_wga_gpu
@@ -65,7 +65,7 @@ else
 	1>&2 echo "Converting chromosome wise fasta to 2bit format"
 	for i in *;
 	do
-	    echo "faToTwoBit $i $(basename -s .fa $i).2bit" >> cmd.sh
+	    echo "faToTwoBit './$i' './$(basename -s .fa $i).2bit'" >> cmd.sh
 	done
   parallel --jobs=$(nproc) < cmd.sh
 	rm cmd.sh *.fa
@@ -79,7 +79,7 @@ else
 	1>&2 echo "Converting chromosome wise fasta to 2bit format"
 	for i in *;
 	do
-	    echo "faToTwoBit $i $(basename -s .fa $i).2bit" >> cmd.sh
+	    echo "faToTwoBit './$i' './$(basename -s .fa $i).2bit'" >> cmd.sh
 	done
   parallel --jobs=$(nproc) < cmd.sh
 	rm cmd.sh *.fa


### PR DESCRIPTION
Cactus needs to support special characters in fasta names such as `>id=0|simCow.chr6|0`.  [This issue](https://github.com/gsneha26/WGA_GPU/issues/12) has an example attached with this type of file. 

But names in this format no longer work with WGA_GPU, I think because of https://github.com/gsneha26/WGA_GPU/commit/55a4efbd5d1fcbcea05ca537f11fe88d3bafa262#diff-2ad817b3c9bb92ff690d016e0a1abfe8.  This PR should fix that. 

Note that quoting or escaping doesn't seem to be sufficient for `faToTwoBit`, but adding the `./` to the front in addition seems to go through.  

