### PR TITLE
Use loop when deleting files instead of passing wildcards to rm

### DIFF
--- a/bin/run_wga_gpu
+++ b/bin/run_wga_gpu
@@ -88,7 +88,7 @@ else
   fi
 
   if [ $ng -eq 0 ]; then
-      rm *.segments *.err
+      for i in *.segments *.err; do rm $i; done
   fi
   cat tmp*
   rm -rf $OUTPUT_FOLDER


### PR DESCRIPTION
`run_wga_gpu` tries to delete too many files when running on human/chimp s3://glennhickey/share/tmpr78wh4vn.tmp

```
run_wga_gpu tmpr78wh4vn.tmp tmpr78wh4vn.tmp --format=cigar --notrivial --step=3- -ambiguous=iupac,100,100 --ydrop=3000

        Sending query block 24 with buffer 0 ...
        Chromosome block 24 interval 1/13 (0:10000000) with buffer 0
        Chromosome block 24 interval 2/13 (10000000:20000000) with buffer 0
        Chromosome block 24 interval 5/13 (40000000:50000000) with buffer 0
        Chromosome block 24 interval 8/13 (70000000:80000000) with buffer 0
        Chromosome block 24 interval 10/13 (90000000:100000000) with buffer 0
        Chromosome block 24 interval 11/13 (100000000:110000000) with buffer 0
        Chromosome block 24 interval 12/13 (110000000:120000000) with buffer 0
        Chromosome block 24 interval 7/13 (60000000:70000000) with buffer 0
        Chromosome block 24 interval 9/13 (80000000:90000000) with buffer 0
        Chromosome block 24 interval 3/13 (20000000:30000000) with buffer 0
        Chromosome block 24 interval 4/13 (30000000:40000000) with buffer 0
        Chromosome block 24 interval 6/13 (50000000:60000000) with buffer 0
        Chromosome block 24 interval 13/13 (120000000:120420998) with buffer 0

        real    64m59.158s
        user    2378m14.678s
        sys     686m11.827s
        /usr/local/bin/run_wga_gpu: line 91: /bin/rm: Argument list too long
```

