### PR TITLE
Erase tmp files as they are output to save space

### DIFF
--- a/scripts/run_segalign_repeat_masker
+++ b/scripts/run_segalign_repeat_masker
@@ -107,12 +107,6 @@ else
     if [ $mk -eq 1 ]; then
       echo "# segalign_repeat_masker end-of-file" >> $output_filename
     fi
-  else
-    echo "#name1  zstart1 end1  name2 zstart2+  end2+"
-    for filename in `for i in tmp*.*; do echo $i; done | sort -V`; do cat $filename && rm $filename; done
-    if [ $mk -eq 1 ]; then
-      echo "# segalign_repeat_masker end-of-file" 
-    fi
   fi
 
   rm -rf $OUTPUT_FOLDER

--- a/scripts/run_segalign_repeat_masker
+++ b/scripts/run_segalign_repeat_masker
@@ -107,8 +107,8 @@ else
     if [ $mk -eq 1 ]; then
       echo "# segalign_repeat_masker end-of-file" >> $output_filename
     fi
-  fi
 
-  rm -rf $OUTPUT_FOLDER
+    rm -rf $OUTPUT_FOLDER
+  fi
 
 fi

--- a/scripts/run_segalign_repeat_masker
+++ b/scripts/run_segalign_repeat_masker
@@ -103,13 +103,13 @@ else
     touch $output_filename
 
     echo "#name1  zstart1 end1  name2 zstart2+  end2+" >> $output_filename
-    for filename in `for i in tmp*.*; do echo $i; done | sort -V`; do cat $filename>> $output_filename; done 
+    for filename in `for i in tmp*.*; do echo $i; done | sort -V`; do cat $filename && rm $filename >> $output_filename; done
     if [ $mk -eq 1 ]; then
       echo "# segalign_repeat_masker end-of-file" >> $output_filename
     fi
   else
     echo "#name1  zstart1 end1  name2 zstart2+  end2+"
-    for filename in `for i in tmp*.*; do echo $i; done | sort -V`; do cat $filename; done 
+    for filename in `for i in tmp*.*; do echo $i; done | sort -V`; do cat $filename && rm $filename; done
     if [ $mk -eq 1 ]; then
       echo "# segalign_repeat_masker end-of-file" 
     fi


### PR DESCRIPTION
I'm running into some disk space issues with preprocessing.  For example, I estimate that the file from #37 will need about 600 gigs just to store the output.  This is a small change to try to keep that 600G from doubling to 1.2T by deleting fragments as they get merged into the final output.  