### PR TITLE
Sync with Cactus

### DIFF
--- a/scripts/run_segalign
+++ b/scripts/run_segalign
@@ -189,8 +189,6 @@ else
       fi
 
     fi
-  else
-    echo "No alignment generated"
   fi
 
   rm -rf $OUTPUT_FOLDER


### PR DESCRIPTION
Two small changes to bring your repo exactly in line with what Cactus uses

* use recent lastz in order to compile on Ubuntu 22.04
* don't write "No alignment generated" for empty alignments -- this inconsistency with the CPU pipeline broke simulation tests in the latest cactus branch (paf_chains)